### PR TITLE
syntax: use negative lookahead to match end of multiline string

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -102,7 +102,7 @@ syn match scalaAnnotation "@[a-zA-Z]\+"
 syn match scalaEmptyString "\"\""
 
 " multi-line string literals
-syn region scalaMultiLineString start="\"\"\"" end="\"\"\"" contains=scalaUnicode
+syn region scalaMultiLineString start="\"\"\"" end="\"\"\"\"\@!" contains=scalaUnicode
 syn match scalaUnicode "\\u[0-9a-fA-F]\{4}" contained
 
 " string literals with escapes


### PR DESCRIPTION
This fixes highlighting for things like:-

 13 consecutive double qoutes (= 1 + 6n),

```
""""""""""""".r
            ^^^^... -- These would be matched as
                      `scalaString' until the next
                       occurring `"`.
```

 11 consecutive double qoutes (= {3 or 4 or 5} + 6n),

```
""""""""""".r
           ^^^... -- These would be matched as
                    `scalaMultiLineString' until the next
                     occurring `"""`.
```

 14 consecutive double qoutes (= 2 + 6n),

```
"""""""""""""".r
            ^^... -- These would be matched as
                    `scalaEmptyString'.
```
