### PR TITLE
Wrap help file conceal usage in a feature check.

### DIFF
--- a/after/syntax/help.vim
+++ b/after/syntax/help.vim
@@ -1,4 +1,6 @@
 let b:current_syntax = ''
 unlet b:current_syntax
 syntax include @ScalaCode syntax/scala.vim
-syntax region rgnScala matchgroup=Ignore concealends start='!sc!' end='!/sc!' contains=@ScalaCode
+if has('conceal')
+  syntax region rgnScala matchgroup=Ignore concealends start='!sc!' end='!/sc!' contains=@ScalaCode
+endif


### PR DESCRIPTION
This avoids an error message for vim versions < 7.3 or otherwise
compiled without the conceal feature.
