### PR TITLE
Fix syntax highlighting for types

### DIFF
--- a/indent/testfile.scala
+++ b/indent/testfile.scala
@@ -74,7 +74,7 @@ class SomeClass {
      *      if (c) 2
      *      else 3
      *    }
-     *    
+     *
      *
      * ---- 2. ----
      *
@@ -93,7 +93,7 @@ class SomeClass {
      *    }
      *
      *    or this...
-     *    
+     *
      *    if (b) 1
      *    else {
      *      if (c)
@@ -103,7 +103,7 @@ class SomeClass {
      *    }
      *
      * ---- 3. ----
-     *    
+     *
      *    if (b) 1
      *    else {
      *      if (c)
@@ -322,7 +322,7 @@ class SomeClass {
     </innertag>
   </outertag>
 
-  val someXML = 
+  val someXML =
     <outertag>
       <innertag>
         <in-innertag>
@@ -370,4 +370,7 @@ class SomeClass {
   }
 
   private[this] def followingFunction = oneliner
+
+  val someFunction: List[(Option[T], Option[U])] = TODO
 }
+

--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -83,7 +83,7 @@ syn match scalaRoot "\<[a-zA-Z][_$a-zA-Z0-9]*\."me=e-1
 syn match scalaMethodCall "\.[a-z][_$a-zA-Z0-9]*"ms=s+1
 
 " type declarations in val/var/def
-syn match scalaType ":\s*\(=>\s*\)\?[._$a-zA-Z0-9]\+\(\[[^]]*\]\+\)\?\(\s*\(<:\|>:\|#\|=>\)\s*[._$a-zA-Z0-9]\+\(\[[^]]*\]\+\)*\)*"ms=s+1
+syn match scalaType ":\s*\(=>\s*\)\?[._$a-zA-Z0-9]\+\(\[.*\]\+\)\?\(\s*\(<:\|>:\|#\|=>\)\s*[._$a-zA-Z0-9]\+\(\[.*\]\+\)*\)*"ms=s+1
 
 " comments
 syn match scalaTodo "[tT][oO][dD][oO]" contained


### PR DESCRIPTION
Hi, 

Before this commit:

```
val someFunction: List[(Option[T], Option[U])] = TODO
                                ^ -- The type syntax highlighting
                                     would have stopped here because of
                                     the closing bracket.
```

I fixed this by updating the regular expression that takes care of syntax highlighting for types (scalaType).

I also added a "test case" in _indent/testfile.scala_ and did my best to check if I introduced a break, but I found any. 

Thanks. 

Samy
