### PR TITLE
Use "//" instead of "/* */" for vim commentstring

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -1,9 +1,9 @@
-
 setlocal textwidth=140
 setlocal shiftwidth=2
 setlocal softtabstop=2
 setlocal expandtab
 setlocal formatoptions=tcqr
+setlocal commentstring=//%s
 
 if globpath(&rtp, 'plugin/fuf.vim') != ''
     "


### PR DESCRIPTION
Of course, both "//" and "/\* */" can be used for comments in Scala; but the nice thing about using "//" is that it plays more nicely with the "vim-commentary" plugin https://github.com/tpope/vim-commentary .  Before this change, if you use vim-commentary and type, for example, "3\\" to comment out three lines, the lines would be commented like this:

```
/* val x = 3 */
/* if (y == 4) */
/*     println("y is 4") */
```

After this change, they would be commented like this:

```
// val x = 3
// if (y == 4)
//     println("y is 4")
```

Note, by default, for Java files, Vim already uses "//" for comments.
