### PR TITLE
Auto-detect *.sbt and "#!/usr/bin/env scala"

### DIFF
--- a/ftdetect/scala.vim
+++ b/ftdetect/scala.vim
@@ -1,1 +1,8 @@
-au BufRead,BufNewFile *.scala set filetype=scala
+fun! s:DetectScala()
+    if getline(1) == '#!/usr/bin/env scala'
+        set filetype=scala
+    endif
+endfun
+
+au BufRead,BufNewFile *.scala,*.sbt set filetype=scala
+au BufRead,BufNewFile * call s:DetectScala()


### PR DESCRIPTION
Auto-detect *.sbt (Scala Build Tool) files and files whose first line is `#!/usr/bin/env scala` as Scala.

Scala allows a "shebang" line to write scripts in Scala and have the shell execute them automatically, as long as the `#!` line is followed by a `!#` line.  E.g. you could write a file called `myscript` that looks like this:

```
#!/usr/bin/env scala
!#

// your Scala code goes here
```

Even though the filename does not end with `.scala`, with this patch, the shebang line will be detected and the `filetype` will be set to `scala`.
