### PR TITLE
Fix syntax highlighting in help files.

### DIFF
--- a/after/syntax/help.vim
+++ b/after/syntax/help.vim
@@ -3,4 +3,6 @@ unlet b:current_syntax
 syntax include @ScalaCode syntax/scala.vim
 if has('conceal')
   syntax region rgnScala matchgroup=Ignore concealends start='!sc!' end='!/sc!' contains=@ScalaCode
+else
+  syntax region rgnScala matchgroup=Ignore start='!sc!' end='!/sc!' contains=@ScalaCode
 endif


### PR DESCRIPTION
Commit 844ce86 accidentally disabled Scala syntax highlighting in help files if you are using a version of Vim that was compiled without the "conceal" feature.

This patch preserves the part of 844ce86 that avoids an error message, but also allows syntax highlighting to work.
