### PR TITLE
Improve syntax-coloring speed

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -10,7 +10,7 @@ elseif exists("b:current_syntax")
 endif
 
 syn case match
-syn sync minlines=50
+syn sync minlines=50 maxlines=100
 
 " most Scala keywords
 syn keyword scalaKeyword case
@@ -131,8 +131,6 @@ syn match scalaXmlComment "<!--\_[^>]*-->" contained
 
 " REPL
 syn match scalaREPLCmdLine "\<scala>\>"
-
-syn sync minlines=100 maxlines=100
 
 " map Scala groups to standard groups
 hi link scalaKeyword Keyword


### PR DESCRIPTION
Syntax coloring was previously done by always starting all the way at the beginning of the file.  This could cause Vim to become very slow when editing .scala files.

With this patch, Vim will only look 100 lines back to get context for syntax-coloring.
