### PR TITLE
Improve syntax highlighting for types

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -83,7 +83,7 @@ syn match scalaRoot "\<[a-zA-Z][_$a-zA-Z0-9]*\."me=e-1
 syn match scalaMethodCall "\.[a-z][_$a-zA-Z0-9]*"ms=s+1
 
 " type declarations in val/var/def
-syn match scalaType ":\s*\%(=>\s*\)\?\%([\._$a-zA-Z0-9]\+\|([^)]\{-1,})\)\%(\[[^:]\{-1,}\]\+\%()\]\+\)*\)\?\%(\s*\%(<:\|>:\|#\|=>\|⇒\)\s*\%([\._$a-zA-Z0-9]\+\|([^)]\{-1,})\)\%(\[[^:]\{-1,}\]\+\%()\]\+\)*\)*\)*"ms=s+1
+syn match scalaType ":\s*\%(=>\s*\)\?\%([\._$a-zA-Z0-9]\+\|([^)]\{-1,})\)\%(\[[^\]]\{-1,}\]\+\%([^)]*)\]\+\)\?\)\?\%(\s*\%(<:\|>:\|#\|=>\|⇒\)\s*\%([\._$a-zA-Z0-9]\+\|([^)]\{-1,})\)\%(\[[^\]]\{-1,}\]\+\%([^)]*)\]\+\)\?\)*\)*"ms=s+1
 " type declarations in case statements
 syn match scalaCaseType "\(case\s\+[_a-zA-Z0-9]\+\)\@<=:\s*[\._$a-zA-Z0-9]\+\(\[[^:]\{-1,}\]\+\)\?"ms=s+1
 


### PR DESCRIPTION
Here are various improvements of the regex used to match types. The commit messages should be enough to explain what are the changes.

Most of the improvements can be seen using the following files:
https://github.com/scalaz/scalaz/blob/master/core/src/main/scala/scalaz/Applicative.scala
https://github.com/scalaz/scalaz/blob/master/core/src/main/scala/scalaz/ListT.scala

Examples: 

Below, the `ListT[M,A]` part after `=` is not matched as a type anymore

``` scala
def ::(a: A)(implicit M:Pure[M]): ListT[M,A] = ListT[M,A](M pure (Yield(a, this)))
```

Functions types with more than one parameter are now matched, as here:

``` scala
def liftA2[A, B, C](a: Z[A], b: Z[B], f: (A, B) => C): Z[C] = apply(fmap(a, f.curried), b)
```

Parenthesis of tuple types mixed with brackets are now matched, as here:

``` scala
def uncons(implicit M:Monad[M]): M[Option[(A, ListT[M,A])]] = 
```

Type annotations in pattern matching are treated differently since the `=>` has not same signification, so the `=>` and the part after is not matched anymore as a type:

``` scala
x match {
    case foo: Foo => doSomething
    case bar: Bar => doSomethingElse
}
```
