### PR TITLE
Remove some settings that should be user preferences.

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -1,8 +1,3 @@
-setlocal textwidth=140
-setlocal shiftwidth=2
-setlocal softtabstop=2
-setlocal expandtab
-setlocal formatoptions=tcqr
 setlocal commentstring=//%s
 
 set makeprg=sbt\ -Dsbt.log.noformat=true\ compile


### PR DESCRIPTION
Hey Derek,

A little disclaimer first, which is that I'm pretty new to vim scripting, settings, etc.

This pull request removes some settings that really don't work with my team's existing formatting, and to me, it also feels that these settings should be left up to the user to define (with autocommands).

Anyway, let me know if this works for you, or if there's some trick I'm not aware of to set my own settings after the filetype detection happens.

cheers,
Geoff
