### PR TITLE
set appropreate &include, &includeexpr, &path and &suffixesadd

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -4,6 +4,10 @@ setlocal softtabstop=2
 setlocal expandtab
 setlocal formatoptions=tcqr
 setlocal commentstring=//%s
+let &l:include = '^\s*import'
+let &l:includeexpr = 'substitute(v:fname,"\\.","/","g")'
+setlocal path+=src/main/scala,src/test/scala
+setlocal suffixesadd=.scala
 
 set makeprg=sbt\ -Dsbt.log.noformat=true\ compile
 set efm=%E\ %#[error]\ %f:%l:\ %m,%C\ %#[error]\ %p^,%-C%.%#,%Z,


### PR DESCRIPTION
Vim's include file search features needs these buffer-local options set.

After this commit you'll be able to use Vim's built in features such as `[I`, `:checkpath` or `gf`.

(The purpose of using `let` instead of `setlocal` was to avoid double escaping for regex.)
