### PR TITLE
Remove editor config from plugin

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -1,8 +1,3 @@
-setlocal textwidth=140
-setlocal shiftwidth=2
-setlocal softtabstop=2
-setlocal expandtab
-setlocal formatoptions=tcqr
 setlocal commentstring=//%s
 
 set makeprg=sbt\ -Dsbt.log.noformat=true\ compile


### PR DESCRIPTION
It's morally objectionable to put editor configuration settings into a
language-support plugin (especially when those settings will cause vim
to ignore settings which the user includes in their vimrc).
