### PR TITLE
Better jump to section for scala

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -178,7 +178,7 @@ function! s:NextSection(backwards)
   let keywords = [ 'def', 'class', 'trait', 'object' ]
   let keywordsOrExpression = s:CreateOrExpression(keywords)
 
-  let modifiers = [ 'public', 'private', 'private\[\w*\]', 'protected', 'abstract', 'case', 'override']
+  let modifiers = [ 'public', 'private', 'private\[\w*\]', 'protected', 'abstract', 'case', 'override', 'implicit', 'final', 'sealed']
   let modifierOrExpression = s:CreateOrExpression(modifiers)
 
   let regex = '^ *('.modifierOrExpression.' )* *'.keywordsOrExpression."\r"


### PR DESCRIPTION
Using [[ && ]] is an easy way to jump to different sections such as beginning of class and functions. Unfortunately doesn't work well for scala by default. I've tried to fix that.
