### PR TITLE
allow embedded highlighting

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -6,6 +6,15 @@ endif
 
 let b:current_syntax = "scala"
 
+function! s:ContainedGroup()
+  try
+    silent syn list @scala
+    return '@scala'
+  catch /E392/
+    return 'TOP'
+  endtry
+endfunction
+
 syn case match
 syn sync minlines=200 maxlines=1000
 
@@ -17,7 +26,7 @@ syn keyword scalaKeyword val nextgroup=scalaNameDefinition,scalaQuasiQuotes skip
 syn keyword scalaKeyword def var nextgroup=scalaNameDefinition skipwhite
 hi link scalaKeyword Keyword
 
-syn region scalaBlock start=/{/ end=/}/ contains=TOP fold
+exe 'syn region scalaBlock start=/{/ end=/}/ contains=' . s:ContainedGroup() . ' fold'
 
 syn keyword scalaAkkaSpecialWord when goto using startWith initialize onTransition stay become unbecome
 hi link scalaAkkaSpecialWord PreProc
@@ -103,13 +112,13 @@ hi link scalaIString String
 hi link scalaTripleIString String
 
 syn match scalaInterpolation /\$[a-zA-Z0-9_$]\+/ contained
-syn region scalaInterpolationB matchgroup=scalaInterpolation start=/\${/ end=/}/ contained contains=TOP
+exe 'syn region scalaInterpolationB matchgroup=scalaInterpolation start=/\${/ end=/}/ contained contains=' . s:ContainedGroup()
 hi link scalaInterpolation Function
 hi link scalaInterpolationB Normal
 
 syn region scalaFString matchgroup=Special start=/f"/ skip=/\\"/ end=/"/ contains=scalaFInterpolation,scalaFInterpolationB,scalaEscapedChar,scalaUnicodeChar
 syn match scalaFInterpolation /\$[a-zA-Z0-9_$]\+\(%[-A-Za-z0-9\.]\+\)\?/ contained
-syn region scalaFInterpolationB matchgroup=scalaFInterpolation start=/${/ end=/}\(%[-A-Za-z0-9\.]\+\)\?/ contained contains=TOP
+exe 'syn region scalaFInterpolationB matchgroup=scalaFInterpolation start=/${/ end=/}\(%[-A-Za-z0-9\.]\+\)\?/ contained contains=' . s:ContainedGroup()
 hi link scalaFString String
 hi link scalaFInterpolation Function
 hi link scalaFInterpolationB Normal


### PR DESCRIPTION
Hey, I'm using vim-scala to highlight codeblocks embedded in markdown files using [vim-pandoc-syntax](https://github.com/vim-pandoc/vim-pandoc-syntax/). A [commit](https://github.com/derekwyatt/vim-scala/commit/7daf2562f1d1efb0955a863abf725ac438c35e82) introduced a `contains=TOP` directive which has since then been added to two other rules.

The embedded codeblock highlighting more or less works by defining a region (the codeblock) and saying that it `contains=@thelanguage`. However, in this case the contained language (scala) is using `contains=TOP` which leads to the images shown in [this issue](https://github.com/vim-pandoc/vim-pandoc-syntax/issues/54).

What I've done to fix this is to create a small function that checks if the `@scala` group is defined, which would mean that this is for highlighting embedded scala codeblocks. If it is, then it uses `contains=@scala` instead of `contains=TOP`, otherwise (regular files) it uses `TOP`.

I tested it in regular scala files and files that embed scala codeblocks and they both work fine.
