### PR TITLE
Set shiftwidth=2 and tabstop=2 in indent/scala.vim

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -12,7 +12,7 @@
 setlocal indentexpr=GetScalaIndent()
 setlocal indentkeys=0{,0},0),!^F,<>>,o,O,e,=case,<CR>
 setlocal autoindent
-setlocal shiftwidth=2
+setlocal shiftwidth=2 tabstop=2 softtabstop=2
 
 "if exists("*GetScalaIndent")
 "    finish


### PR DESCRIPTION
cf #60

Overwrite user's tabstop and shiftwidth to 2 to respect scala's indentation style http://docs.scala-lang.org/style/indentation.html.
