### PR TITLE
Add escaped quote ('\"') character.

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -37,7 +37,7 @@ syn match scalaSymbol /'[_A-Za-z0-9$]\+/
 hi link scalaSymbol Number
 
 syn match scalaChar /'.'/
-syn match scalaEscapedChar /\\[\\ntbrf]/
+syn match scalaEscapedChar /\\[\\"ntbrf]/
 syn match scalaUnicodeChar /\\u[A-Fa-f0-9]\{4}/
 hi link scalaChar Character
 hi link scalaEscapedChar Function


### PR DESCRIPTION
Syntax highlighting breaks when using `'\"'` for character comparisons.

![vim-syntax-small](https://cloud.githubusercontent.com/assets/916295/3469379/dcf4a278-02ad-11e4-9649-ae2bf4dcc0bb.png)
This commit solves the problem. 

Moreover, syntax highlighting is different for case, `'\''`, but I am not sure how to approach to that. Adding `'` to `scalaEscapedChar` does not solve, since in that case syntax is highlighted only for `'\'`.
