### PR TITLE
Use non-greedy operators for stripping out quoted contents of lines

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -36,12 +36,12 @@ endfunction
 
 function! scala#GetLine(lnum)
   let line = substitute(getline(a:lnum), '//.*$', '', '')
-  let line = substitute(line, '"[^"]*"', '""', 'g')
+  let line = substitute(line, '"\(.\|\\"\)\{-}"', '""', 'g')
   return line
 endfunction
 
 function! scala#CountBrackets(line, openBracket, closedBracket)
-  let line = substitute(a:line, '"\(.\|\\"\)*"', '', 'g')
+  let line = substitute(a:line, '"\(.\|\\"\)\{-}"', '', 'g')
   let open = substitute(line, '[^' . a:openBracket . ']', '', 'g')
   let close = substitute(line, '[^' . a:closedBracket . ']', '', 'g')
   return strlen(open) - strlen(close)

--- a/indent/testfile.scala
+++ b/indent/testfile.scala
@@ -212,6 +212,7 @@ class SomeClass {
   def func = {
     val reply = new Something()
     some.block {
+      def foo("string", bar("string"))
       new X {
         statement
         statement


### PR DESCRIPTION
This avoids problems where lines with brackets/parens between string literals get gobbled up.
