### PR TITLE
Fix indentation when virtualedit is off

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -102,7 +102,7 @@ function! scala#CurlyMatcher()
   if scala#CountParens(scala#GetLine(matchline)) < 0
     let savedpos = getpos('.')
     call setpos('.', [savedpos[0], matchline, 9999, savedpos[3]])
-    call searchpos('{', 'Wb')
+    call searchpos('{', 'Wbc')
     call searchpos(')', 'Wb')
     let [lnum, colnum] = searchpairpos('(', '', ')', 'Wbn')
     call setpos('.', savedpos)
@@ -133,7 +133,7 @@ function! scala#GetLineAndColumnThatMatchesBracket(openBracket, closedBracket)
     call searchpos(a:closedBracket . '\ze[^' . a:closedBracket . a:openBracket . ']*' . a:openBracket, 'W')
   else
     call setpos('.', [savedpos[0], savedpos[1], 9999, savedpos[3]])
-    call searchpos(a:closedBracket, 'Wb')
+    call searchpos(a:closedBracket, 'Wbc')
   endif
   let [lnum, colnum] = searchpairpos(a:openBracket, '', a:closedBracket, 'Wbn')
   call setpos('.', savedpos)


### PR DESCRIPTION
after calling `setpos` to put the cursor at column 9999, if `virtualedit` is enabled, this will presumably be way past the last character, but if it is disabled, the cursor will be sitting _on_ the last character (which is often a closing bracket/paren).  Adding the 'c' flag to `searchpos` will tell it to accept a match under the cursor if it exists.
