### PR TITLE
updating README to new Vundle syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ manage your plugins.
 If you have Vundle installed, simply add the following to your .vimrc:
 
 ```vim
-Bundle 'derekwyatt/vim-scala'
+Plugin 'derekwyatt/vim-scala'
 ```
 
 and then run
 
 ```vim
-:BundleInstall
+:PluginInstall
 ```
 
 to install it.


### PR DESCRIPTION
Really nice plugin. I just updated the Vundle instructions to use the new syntax. You can check the [deprecation warning here](https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L383).