### PR TITLE
Restore HTML for comments, main_syntax embedding convention

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -1,13 +1,15 @@
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
-  finish
+if !exists('main_syntax')
+  if version < 600
+    syntax clear
+  elseif exists("b:current_syntax")
+    finish
+  endif
+  let main_syntax = 'scala'
 endif
 
 scriptencoding utf-8
 
-let b:current_syntax = "scala"
-
+" Allows for embedding, see #59; main_syntax convention instead? Refactor TOP
 function! s:ContainedGroup()
   try
     silent syn list @scala
@@ -16,6 +18,9 @@ function! s:ContainedGroup()
     return 'TOP'
   endtry
 endfunction
+
+syn include @scalaHtml syntax/html.vim  " Doc comment HTML
+unlet! b:current_syntax
 
 syn case match
 syn sync minlines=200 maxlines=1000
@@ -178,3 +183,9 @@ syn match scalaAkkaFSMGotoUsing /\<using\>/
 syn match scalaAkkaFSMGotoUsing /\<goto\>/
 hi link scalaAkkaFSM PreProc
 hi link scalaAkkaFSMGotoUsing PreProc
+
+let b:current_syntax = 'scala'
+
+if main_syntax ==# 'scala'
+  unlet main_syntax
+endif


### PR DESCRIPTION
HTML is discouraged in favor of the wiki syntax, but hey, it's still supported.

The include for `syntax/html.vim` was removed in 07c16c7d77. The `@scalaHtml` cluster reference was put back in 3203d67af3 but the include wasn’t. All includes need to be done before any of our Scala syntax configuration, and then their `b:current_syntax` unlet.

The `main_syntax` convention is commonly used by syntax definitions that want to support embedding/being embedded, e.g. to be highlighted in fenced code blocks in a Markdown file. More about this in another pull request in a moment. vim-markdown and vim-liquid are some examples that support the pattern, and numerous syntax defs in the standard runtime files use it.