### PR TITLE
Enable spellcheck in comments, and waxing about the syntax def more generally...

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -8,12 +8,17 @@ scriptencoding utf-8
 
 let b:current_syntax = "scala"
 
+" Allows for embedding, see #59; main_syntax convention instead? Refactor TOP
+"
+" The @Spell here is a weird hack, it means *exclude* if the first group is
+" TOP. Otherwise we get spelling errors highlighted on code elements that
+" match scalaBlock, even with `syn spell notoplevel`.
 function! s:ContainedGroup()
   try
     silent syn list @scala
-    return '@scala'
+    return '@scala,@NoSpell'
   catch /E392/
-    return 'TOP'
+    return 'TOP,@Spell'
   endtry
 endfunction
 
@@ -146,7 +151,7 @@ syn match scalaTypeAnnotationParameter /@\<[`_A-Za-z0-9$]\+\>/ contained
 hi link scalaTypeOperator Keyword
 hi link scalaTypeAnnotationParameter Function
 
-syn region scalaMultilineComment start="/\*" end="\*/" contains=scalaMultilineComment,scalaDocLinks,scalaParameterAnnotation,scalaCommentAnnotation,scalaCommentCodeBlock,@scalaHtml keepend
+syn region scalaMultilineComment start="/\*" end="\*/" contains=scalaMultilineComment,scalaDocLinks,scalaParameterAnnotation,scalaCommentAnnotation,scalaCommentCodeBlock,@scalaHtml,@Spell keepend
 syn match scalaCommentAnnotation "@[_A-Za-z0-9$]\+" contained
 syn match scalaParameterAnnotation "@param" nextgroup=scalaParamAnnotationValue skipwhite contained
 syn match scalaParamAnnotationValue /[`_A-Za-z0-9$]\+/ contained
@@ -162,7 +167,7 @@ hi link scalaCommentCodeBlock String
 syn match scalaAnnotation /@\<[`_A-Za-z0-9$]\+\>/
 hi link scalaAnnotation PreProc
 
-syn match scalaTrailingComment "//.*$"
+syn match scalaTrailingComment "//.*$" contains=@Spell
 hi link scalaTrailingComment Comment
 
 syn match scalaAkkaFSM /goto([^)]*)\_s\+\<using\>/ contains=scalaAkkaFSMGotoUsing

--- a/syntax/testfile.scala
+++ b/syntax/testfile.scala
@@ -43,7 +43,7 @@ def x(): Unit = {
 
 class ScalaClass(i: Int = 12, b: Trait[A, Trait[B, C]]) extends B with SomeTrait[A, B[String], D] {
   /**
-   * I forgot comments! [[scala.Option]]
+   * I forgot comments! We spelcheck them. [[scala.Option]]
    *
    * {{{
    * scala> This is a REPL line
@@ -52,10 +52,10 @@ class ScalaClass(i: Int = 12, b: Trait[A, Trait[B, C]]) extends B with SomeTrait
    *
    * <li></li>
    *
-   * @param parameter Explanation of the parameter.
+   * @param parameter Explanation of the parameter. Speling.
    * @return 
    */
-  val thing = "A String" // this is a trailing comment
+  val thing = "A String" // this is a trailing comment, spelchecked too
   val thing = "A String with a \" in it"
   val intString = "A string with $stuff // and a comment in it"
   val intString = s"A string /* a comment and */ with $stuff and ${stuff} in it"
@@ -160,6 +160,7 @@ class ScalaClass(i: Int = 12, b: Trait[A, Trait[B, C]]) extends B with SomeTrait
   val something = s"""bar="foo""""
   val something = f"""bar="foo""""
   val something = """bar="foo""""
+  val something = s"Interpolatin' fancy expressions ${bar map (_.toString)}"
 
   def someFunc[A <: B, X =:= Y]
 


### PR DESCRIPTION
Okay, this may sound more complicated than it looks, but I think it should be even simpler. Bear with me and if there's feedback I'll try to incorporate it, perhaps on another branch if this is good enough for spell checking as-is.

This works, but it actually took awhile to make sense of some trickiness of `contains=TOP` and I'm concerned that it could get trickier still if more is built upon `scalaBlock` being defined that way. Granted I'm not very experienced with Vim syntax definitions so maybe it's just my growing pains. (But it doesn't make total semantic sense: `scalaBlock` is defined with `contains=TOP` which is effectively saying it's equivalent to the Scala top level, but it's matched by curly bracket surroundings. `package` is one top-level statement that cannot be within a block structure).

Anyway, a couple of points about this change:

  1. It only behaves correctly with the counter-intuitive `@Spell` included with `TOP`. When additional groups are listed with `TOP`, the semantic becomes exclusion instead of inclusion. This sucks because it reads as a surprise and basically needs a comment to make sense of it.
  2. I have a feeling `main_syntax` (see #80) could be used to eliminate the `ContainedGroup` function entirely, but I don't really understand where `@scala` came from. See below.

Regarding the first, without the `@Spell` in `contains=TOP,@Spell`, if you opened `syntax/testfile.scala` you'd see it highlights as spelling errors many code elements that match as `scalaBlock`, like `println`s, param names in `Test.test`, and a bunch more.

Setting `syntax spell notoplevel` did not fix this. The default of `syntax spell default` should, to my understanding, also not spellcheck toplevel if any explicit `@Spell` or `@NoSpell` is used somewhere in the syntax def (`:h :syn-spell`). But it seems like `contains=TOP` runs afoul of either of these, requiring the explicit exclusion.

I'll poke around more in other syntax defs for inspiration on effective patterns and potential pitfalls. Some build up their own explicit "local top", others don't. I'm open to experience and advice anyone has to share. I'd like to get XML literals working through an include but I think we're still laying some fundamental foundations of the syntax.