### PR TITLE
Fixing multi-line parameter support

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -543,7 +543,7 @@ function! GetScalaIndent()
     let ind = ind - 1
   endif
 
-  if scala#LineEndsInIncomplete(curline)
+  if scala#LineEndsInIncomplete(prevline)
     call scala#ConditionalConfirm("19")
     return ind
   endif

--- a/indent/testfile.scala
+++ b/indent/testfile.scala
@@ -1,5 +1,5 @@
 /**
- * Commets are here
+ * Comments are here
  */
 class SomeClass {
   val someval = SomeObject.makeWithSomething
@@ -18,6 +18,13 @@ class SomeClass {
   def aSingleLineDef = someval + 12
 
   def main(args: Array[String]) = run(20000, 20000)
+
+  def multilineParams(
+    x: Int,
+    y: Int
+  ) = {
+    ???
+  }
 
   // This
   def aMultiLineSingleStatementDefWithBraces = {
@@ -231,7 +238,7 @@ class SomeClass {
         statement
       }
     },
-  otherParam) // comment
+    otherParam) // comment
 
   class AnotherSomeClass {
     this: Actor =>


### PR DESCRIPTION
I think this was almost certainly a typo in the original script; the behavior would be very odd otherwise.