### PR TITLE
Set value for the 'comments' option

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -1,7 +1,13 @@
 setlocal formatoptions+=ro
-setlocal commentstring=//%s
+
+" Just like c.vim, but additionally doesn't wrap text onto /** line when
+" formatting. Doesn't bungle bulleted lists when formatting.
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/**,mb:*,ex:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
 let &l:include = '^\s*import'
 let &l:includeexpr = 'substitute(v:fname,"\\.","/","g")'
+
 setlocal path+=src/main/scala,src/test/scala
 setlocal suffixesadd=.scala
 


### PR DESCRIPTION
Vim's default value for this option is `s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-`, which you just have to read `:help 'comments'` to make any sense of, but it's basically a "try to do the right thing for a wide range of possible file types" compromise. In particular, `b:#` means "hash is a comment if followed by whitespace, so not e.g. `#define` in a C-like". Another plugin I use (perhaps dubiously) got a little tripped up by this, thinking it was an indication that `#` is a valid comment leader in Scala.

This change sets the option to the same value as in the core c.vim runtime files, with one addition: the explicit start/middle/end trio for `/**`. Without this, it was wrapping text onto the `/**` opening line when formatting with `gq`.

In general this follows traditional Javadoc style. I know [there are Scaladoc style suggestions][1] about how the stars should align differently (heh), but I've never heard a convincing argument for that convention and *have* seen (unexplained) disagreement among people who get to publish those things, so that probably explains why most of the community seems to ignore it and stick to the Java way. Anyone who feels strongly about the blessed Scaladoc style can always tweak the setting with their own autocommand, `after/ftplugin`, project-local vimrc, or whatever.

The first start/middle/end trio keeps bulleted list items with dashes from getting munged together by `gq` formatting inside comments. It'd be cool if `{{{` code blocks and even Scaladoc ordered list syntax could be supported this way too, but the `comments` option doesn't seem to be a sharp enough tool to handle those cleanly or at all.

[1]: http://docs.scala-lang.org/style/scaladoc.html