### PR TITLE
syntax: Remove implicitly and require from keywords?

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -115,7 +115,7 @@ syn match scalaCaseFollowing /\<[_\.A-Za-z0-9$]\+\>/ contained
 syn match scalaCaseFollowing /`[^`]\+`/ contained
 hi link scalaCaseFollowing Special
 
-syn keyword scalaKeywordModifier abstract override final lazy implicit implicitly private protected sealed null require super
+syn keyword scalaKeywordModifier abstract override final lazy implicit private protected sealed null super
 hi link scalaKeywordModifier Function
 
 syn keyword scalaSpecial this true false ne eq


### PR DESCRIPTION
Unlike the other things in the list, they're functions (user definable),
not keywords (language syntax). Thoughts?