### PR TITLE
syntax: Move implicitly and require from scalaKeywordModifier to scalaSpecialFunction

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -115,8 +115,10 @@ syn match scalaCaseFollowing /\<[_\.A-Za-z0-9$]\+\>/ contained
 syn match scalaCaseFollowing /`[^`]\+`/ contained
 hi link scalaCaseFollowing Special
 
-syn keyword scalaKeywordModifier abstract override final lazy implicit implicitly private protected sealed null require super
+syn keyword scalaKeywordModifier abstract override final lazy implicit private protected sealed null super
+syn keyword scalaSpecialFunction implicitly require
 hi link scalaKeywordModifier Function
+hi link scalaSpecialFunction Function
 
 syn keyword scalaSpecial this true false ne eq
 syn keyword scalaSpecial new nextgroup=scalaInstanceDeclaration skipwhite


### PR DESCRIPTION
Lets the user customize special functions independently from language
keywords.

(was: https://github.com/derekwyatt/vim-scala/pull/98)
