### PR TITLE
Detect scala script by name

### DIFF
--- a/ftdetect/scala.vim
+++ b/ftdetect/scala.vim
@@ -4,7 +4,7 @@ fun! s:DetectScala()
     endif
 endfun
 
-au BufRead,BufNewFile *.scala set filetype=scala
+au BufRead,BufNewFile *.scala[s] set filetype=scala
 au BufRead,BufNewFile * call s:DetectScala()
 
 " Install vim-sbt for additional syntax highlighting.


### PR DESCRIPTION
Scala script names end in .scalas
This patch enables vim-scala to correctly detect them as Scala programs