### PR TITLE
Abort scala.xpt.vim if xptemplates isn't installed

### DIFF
--- a/ftplugin/scala/scala.xpt.vim
+++ b/ftplugin/scala/scala.xpt.vim
@@ -1,3 +1,6 @@
+if !exists(':XPTemplate')
+    finish
+endif
 
 XPTemplate priority=lang
 


### PR DESCRIPTION
This fixes issue #28 for users of bundle managers like NeoBundle, Pathogen, or Vundle. Temporary fix until issue #74 is closed.
