### PR TITLE
Empty backtick literals are invalid scala syntax

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -130,7 +130,7 @@ hi link scalaKeywordModifier Function
 syn keyword scalaSpecial this true false ne eq
 syn keyword scalaSpecial new nextgroup=scalaInstanceDeclaration skipwhite
 syn match scalaSpecial "\%(=>\|⇒\|<-\|←\|->\|→\)"
-syn match scalaSpecial /`[^`]*`/  " Backtick literals
+syn match scalaSpecial /`[^`]\+`/  " Backtick literals
 hi link scalaSpecial PreProc
 
 syn keyword scalaExternal package import


### PR DESCRIPTION
The issue
---

I'm trying to put together a simple syntax file for https://github.com/marconilanna/REPLesent

The issue I'm running into is with:
```
syn match scalaSpecial /`[^`]*`/  " Backtick literals
```

Since it's `*`, not `\+`, once the syntax block starts, it never ends.

    ```
    object Foo {

        def hey: String = ""
    }
    ```

    def stillHighlighted = "It is!"

The good news
---

It turns out that this isn't valid Scala anyway, so everybody wins!
```
Welcome to Scala version 2.11.6 (OpenJDK 64-Bit Server VM, Java 1.8.0_91).
Type in expressions to have them evaluated.
Type :help for more information.

scala> ``
<console>:1: error: empty quoted identifier
       ``
       ^
```

Future work
---
My syntax definition is currently just enabling Scala highlighting inside code blocks,
```
syntax include @Scala syntax/scala.vim
syntax region replesentBlock start=/```/ end=/```/ contains=@Scala
```
but once it's finished (able to handle the other markup), it'll be submitted to the actual project itself.