### PR TITLE
Configure asterisk alignment in multiline comments to match scaladoc recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ There are different modes for import sorting available. For details, please
 consult the vimdoc help with
 
     :help :SortScalaImports
+
+##Scaladoc comment indentation
+
+By default, the plugin indents documentation comments according to the standard
+Javadoc format
+
+    /**
+     * This is a doc comment using Javadoc-style indentation.
+     */
+
+To enable the indentation standard as recommended for Scaladoc comments (from
+http://docs.scala-lang.org/style/scaladoc.html, since Scaladoc2), add the
+command ``let g:scala_scaladoc_indent = 1`` to .vimrc file, e.g:
+
+    /** This is a Scaladoc comment using the recommended indentation.
+      * let g:scala_scaladoc_indent = 1
+      */

--- a/doc/scala.txt
+++ b/doc/scala.txt
@@ -40,6 +40,22 @@ See |scala-mappings|.
 >
     let g:scala_use_default_keymappings = 1
 <
+
+                                                   *'g:scala_scaladoc_indent'*
+By default, the plugin indents documentation comments according to the
+standard Javadoc format.
+    /**
+     * This is a doc comment using Javadoc-style indentation.
+     */
+Set this option to enable the indentation standard as recommended for Scaladoc
+comments.
+    /** This is a Scaladoc comment using 
+      * the recommended indentation.
+      */
+>
+    let g:scala_scaladoc_indent = 1
+<
+                                                     
 ==============================================================================
 COMMANDS                                        *scala-commands*
 

--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -16,7 +16,11 @@ silent! setlocal formatoptions+=j
 
 " Just like c.vim, but additionally doesn't wrap text onto /** line when
 " formatting. Doesn't bungle bulleted lists when formatting.
-setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/**,mb:*,ex:*/,s1:/*,mb:*,ex:*/,://
+if get(g:, 'scala_scaladoc_indent', 0)
+  setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s2:/**,mb:*,ex:*/,s1:/*,mb:*,ex:*/,://
+else
+  setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/**,mb:*,ex:*/,s1:/*,mb:*,ex:*/,://
+endif
 setlocal commentstring=//\ %s
 
 setlocal shiftwidth=2 softtabstop=2 expandtab

--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -376,12 +376,17 @@ function! GetScalaIndent()
   let prevline = scala#GetLine(prevlnum)
   let curlnum = v:lnum
   let curline = scala#GetLine(curlnum)
+  if get(g:, 'scala_scaladoc_indent', 0)
+    let star_indent = 2
+  else
+    let star_indent = 1
+  end
 
   if prevline =~ '^\s*/\*\*'
     if prevline =~ '\*/\s*$'
       return ind
     else
-      return ind + 1
+      return ind + star_indent
     endif
   endif
 
@@ -536,7 +541,7 @@ function! GetScalaIndent()
   if prevline =~ '^\s*\*/'
    \ || prevline =~ '*/\s*$'
     call scala#ConditionalConfirm("18")
-    let ind = ind - 1
+    let ind = ind - star_indent
   endif
 
   if scala#LineEndsInIncomplete(prevline)


### PR DESCRIPTION
Adds an option ``g:scala_scaladoc_indent = 1`` to enable comments using the official Scaladoc style.

    /**
      * Scaladoc comment with g:scala_scaladoc_indent = 1
      */

    /**
     * Doc comment with g:scala_scaladoc_indent = 0 or not set.  This is the current behaviour
     */

Referenced in https://github.com/derekwyatt/vim-scala/issues/116