### PR TITLE
Use shiftwidth() instead of &shiftwidth

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -409,19 +409,19 @@ function! GetScalaIndent()
     if prevline =~ '^\s*\.'
       return ind
     else
-      return ind + &shiftwidth
+      return ind + shiftwidth()
     endif
   endif
 
   " Indent html literals
   if prevline !~ '/>\s*$' && prevline =~ '^\s*<[a-zA-Z][^>]*>\s*$'
     call scala#ConditionalConfirm("3")
-    return ind + &shiftwidth
+    return ind + shiftwidth()
   endif
 
   " assumes curly braces around try-block
   if curline =~ '^\s*}\s*\<catch\>'
-    return ind - &shiftwidth
+    return ind - shiftwidth()
   elseif curline =~ '^\s*\<catch\>'
     return ind
   endif
@@ -435,7 +435,7 @@ function! GetScalaIndent()
         \ || prevline =~ '^\s*\%(}\s*\)\?\<else\>\s*$'
         \ || prevline =~ '=\s*$'
     call scala#ConditionalConfirm("4")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   elseif prevline =~ '^\s*\<\%(}\?\s*else\s\+\)\?if\>' && curline =~ '^\s*}\?\s*\<else\>'
     return ind
   endif
@@ -444,7 +444,7 @@ function! GetScalaIndent()
   let bracketCount = scala#CountBrackets(prevline, '{', '}')
   if bracketCount > 0 || prevline =~ '.*{\s*$'
     call scala#ConditionalConfirm("5b")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   elseif bracketCount < 0
     call scala#ConditionalConfirm("6b")
     " if the closing brace actually completes the braces entirely, then we
@@ -472,7 +472,7 @@ function! GetScalaIndent()
     let bracketCount = scala#CountBrackets(prevline, '(', ')')
     if bracketCount > 0 || prevline =~ '.*(\s*$'
       call scala#ConditionalConfirm("5a")
-      let ind = ind + &shiftwidth
+      let ind = ind + shiftwidth()
     elseif bracketCount < 0
       call scala#ConditionalConfirm("6a")
       " if the closing brace actually completes the braces entirely, then we
@@ -494,7 +494,7 @@ function! GetScalaIndent()
       else
         " This is the only part that's different from from the '{', '}' one below
         " Yup... some refactoring is necessary at some point.
-        let ind = ind + (bracketCount * &shiftwidth)
+        let ind = ind + (bracketCount * shiftwidth())
         let lineCompletedBrackets = 1
       endif
     endif
@@ -503,7 +503,7 @@ function! GetScalaIndent()
   if curline =~ '^\s*}\?\s*\<else\>\%(\s\+\<if\>\s*(.*)\)\?\s*{\?\s*$' &&
    \ ! scala#LineIsCompleteIf(prevline) &&
    \ prevline !~ '^.*}\s*$'
-    let ind = ind - &shiftwidth
+    let ind = ind - shiftwidth()
   endif
 
   " Subtract a 'shiftwidth' on '}' or html
@@ -514,7 +514,7 @@ function! GetScalaIndent()
     return indent(matchline)
   elseif curline =~ '^\s*</[a-zA-Z][^>]*>'
     call scala#ConditionalConfirm("14c")
-    return ind - &shiftwidth
+    return ind - shiftwidth()
   endif
 
   let prevParenCount = scala#CountParens(prevline)
@@ -526,7 +526,7 @@ function! GetScalaIndent()
   let prevCurlyCount = scala#CountCurlies(prevline)
   if prevCurlyCount == 0 && prevline =~ '^.*\%(=>\|⇒\)\s*$' && prevline !~ '^\s*this\s*:.*\%(=>\|⇒\)\s*$' && curline !~ '^\s*\<case\>'
     call scala#ConditionalConfirm("16")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   endif
 
   if ind == originalIndentValue && curline =~ '^\s*\<case\>'
@@ -552,7 +552,7 @@ function! GetScalaIndent()
   if scala#LineIsAClosingXML(prevline)
     if scala#LineCompletesXML(prevlnum, prevline)
       call scala#ConditionalConfirm("20a")
-      return ind - &shiftwidth
+      return ind - shiftwidth()
     else
       call scala#ConditionalConfirm("20b")
       return ind
@@ -563,7 +563,7 @@ function! GetScalaIndent()
     "let indentMultiplier = scala#LineCompletesDefValr(prevlnum, prevline)
     "if indentMultiplier != 0
     "  call scala#ConditionalConfirm("19a")
-    "  let ind = ind - (indentMultiplier * &shiftwidth)
+    "  let ind = ind - (indentMultiplier * shiftwidth())
     let defValrLine = scala#Test(prevlnum, prevline, '{', '}')
     if defValrLine != -1
       call scala#ConditionalConfirm("21a")
@@ -572,10 +572,10 @@ function! GetScalaIndent()
       call scala#ConditionalConfirm("21b")
       if scala#GetLine(prevnonblank(prevlnum - 1)) =~ '^.*\<else\>\s*\%(//.*\)\?$'
         call scala#ConditionalConfirm("21c")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       elseif scala#LineCompletesIfElse(prevlnum, prevline)
         call scala#ConditionalConfirm("21d")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       elseif scala#CountParens(curline) < 0 && curline =~ '^\s*)' && scala#GetLine(scala#GetLineThatMatchesBracket('(', ')')) =~ '.*(\s*$'
         " Handles situations that look like this:
         " 
@@ -589,7 +589,7 @@ function! GetScalaIndent()
         "     10
         "   ).somethingHere()
         call scala#ConditionalConfirm("21e")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       endif
     endif
   endif


### PR DESCRIPTION
Recently, I sent a patch to vim_dev, you know, Vim developer mailing list.
[Remaining &shiftwidth references in indent plugins - Google Groups](https://groups.google.com/forum/#!topic/vim_dev/BcDThxEkwNA)

shiftwidth(), introduced in Vim 7.4.694, should be used instead of
direct reference to '&shiftwidth' option value. 'set sw=0' makes
Vim behave like 'set sw={tabstop option value}' (:help shiftwidth()).

But currently this feature does not work on your indent plugins
due to the direct reference '&shiftwidth'.

And I guess you are the maintainer of this indent plugin.
**If you include this pull request, would you like to send the latest indent plugin to Bram?**