### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This is a "bundle" for Vim that builds off of the initial Scala plugin modules
 by Stefan Matthias Aust and adds some more "stuff" that I find useful, including
 all of my notes and customizations.
 
-##Installation
+## Installation
 
 You really should be using Tim Pope's [Pathogen](https://github.com/tpope/vim-pathogen) module for Vim (http://tammersaleh.com/posts/the-modern-vim-config-with-pathogen) if you're going to clone this repository because, well... you should.
 
-###Using the command-line
+### Using the command-line
 
 Using wget:
 
@@ -19,7 +19,7 @@ Using cURL:
 
 ```mkdir -p ~/.vim/{ftdetect,indent,syntax} && for d in ftdetect indent syntax ; do curl -o ~/.vim/$d/scala.vim https://raw.githubusercontent.com/derekwyatt/vim-scala/master/$d/scala.vim; done```
 
-###Vundle
+### Vundle
 Alternatively, you can use [Vundle](https://github.com/gmarik/vundle) to
 manage your plugins.
 
@@ -37,7 +37,7 @@ and then run
 
 to install it.
 
-##Sorting of import statements
+## Sorting of import statements
     :SortScalaImports
 
 There are different modes for import sorting available. For details, please
@@ -45,7 +45,7 @@ consult the vimdoc help with
 
     :help :SortScalaImports
 
-##Scaladoc comment indentation
+## Scaladoc comment indentation
 
 By default, the plugin indents documentation comments according to the standard
 Javadoc format


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
