### PR TITLE
Set filetype for scala worksheets

### DIFF
--- a/ftdetect/scala.vim
+++ b/ftdetect/scala.vim
@@ -4,7 +4,7 @@ fun! s:DetectScala()
     endif
 endfun
 
-au BufRead,BufNewFile *.scala set filetype=scala
+au BufRead,BufNewFile *.scala,*.sc set filetype=scala
 au BufRead,BufNewFile * call s:DetectScala()
 
 " Install vim-sbt for additional syntax highlighting.


### PR DESCRIPTION
This is useful for working with the [ammonite](http://ammonite.io/) REPL, which uses the `*.sc` extension for scala worksheets.