### PR TITLE
ftplugin: Fix syntax for include/includexpr options

### DIFF
--- a/ftplugin/scala.vim
+++ b/ftplugin/scala.vim
@@ -25,8 +25,8 @@ setlocal commentstring=//\ %s
 
 setlocal shiftwidth=2 softtabstop=2 expandtab
 
-setlocal include='^\s*import'
-setlocal includeexpr='substitute(v:fname,"\\.","/","g")'
+setlocal include=^\\s*import
+setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 
 setlocal path+=src/main/scala,src/test/scala
 setlocal suffixesadd=.scala


### PR DESCRIPTION
In 1f90f5e59b2664e1e4f6a0abbd253d0f106101dd, these options were moved to
the ftplugin and changed from "let &l:" statements to "setlocal".
However, the right-hand side of the statement kept the let-style syntax.