### PR TITLE
Fix indentation for defs and vals with modifiers

### DIFF
--- a/indent/scala.vim
+++ b/indent/scala.vim
@@ -17,7 +17,10 @@ if exists("*GetScalaIndent")
   finish
 endif
 
-let s:defMatcher = '\%(\%(private\|protected\)\%(\[[^\]]*\]\)\?\s\+\|abstract\s\+\|override\s\+\)*\<def\>'
+let s:annotationMatcher = '@[A-Za-z._]\+\s\+'
+let s:modifierMatcher = s:annotationMatcher . '\|\%(private\|protected\)\%(\[[^\]]*\]\)\?\s\+\|abstract\s\+\|override\s\+\|final\s\+'
+let s:defMatcher = '\%(' . s:modifierMatcher . '\)*\<def\>'
+let s:valMatcher = '\%(' . s:modifierMatcher . '\|lazy\s\+\)*\<va[lr]\>'
 let s:funcNameMatcher = '\w\+'
 let s:typeSpecMatcher = '\%(\s*\[\_[^\]]*\]\)'
 let s:defArgMatcher = '\%((\_.\{-})\)'
@@ -181,7 +184,7 @@ function! scala#NumberOfBraceGroups(line)
 endfunction
 
 function! scala#MatchesIncompleteDefValr(line)
-  if a:line =~ '^\s*\%(' . s:defMatcher . '\|\<va[lr]\>\).*[=({]\s*$'
+  if a:line =~ '^\s*\%(' . s:defMatcher . '\|' . s:valMatcher . '\).*[=({]\s*$'
     return 1
   else
     return 0
@@ -431,7 +434,7 @@ function! GetScalaIndent()
   " If 'val', 'var', 'def' end with =, this is a one-line block
   if (prevline =~ '^\s*\<\%(\%(}\?\s*else\s\+\)\?if\|for\|while\)\>.*[)=]\s*$' && scala#NumberOfBraceGroups(prevline) <= 1)
         \ || prevline =~ '^\s*' . s:defMatcher . '.*=\s*$'
-        \ || prevline =~ '^\s*\<va[lr]\>.*[=]\s*$'
+        \ || prevline =~ '^\s*' . s:valMatcher . '.*[=]\s*$'
         \ || prevline =~ '^\s*\%(}\s*\)\?\<else\>\s*$'
         \ || prevline =~ '=\s*$'
     call scala#ConditionalConfirm("4")

--- a/indent/testfile.scala
+++ b/indent/testfile.scala
@@ -380,6 +380,25 @@ class SomeClass {
       }
   }
 
+  /** annotations should not change indent, also allow modifiers for vals */
+  @annotation.tailrec def someFunction =
+    some stuff here
+
+  final def foo2 =
+    some stuff here
+
+  final val someValue =
+    some stuff here
+
+  private val someValue =
+    some stuff here
+
+  lazy val someValue =
+    some stuff here
+
+  @annotation.foo val someValue =
+    some stuff here
+
   private[this] def followingFunction = oneliner
 
   val someFunction: List[(Option[T], Option[U])] = TODO


### PR DESCRIPTION
Fixes indentation for defs, vals and vars with annotation on same line, final defs and vals/vars, and several other keywords for vals/vars (like private/lazy/...).

Example (added to testfile.scala):
```scala
  @annotation.tailrec def someFunction =
    some stuff here

  final def foo2 =
    some stuff here

  final val someValue =
    some stuff here

  private val someValue =
    some stuff here

  lazy val someValue =
    some stuff here

  @annotation.foo val someValue =
    some stuff here

  private[this] def followingFunction = oneliner
```
Before fix, this was indented to:
```scala
  @annotation.tailrec def someFunction =
    some stuff here

    final def foo2 =
      some stuff here

      final val someValue =
        some stuff here

        private val someValue =
          some stuff here

          lazy val someValue =
            some stuff here

            @annotation.foo val someValue =
              some stuff here

              private[this] def followingFunction = oneliner
```