### PR TITLE
Add column number into errorformat

### DIFF
--- a/compiler/sbt.vim
+++ b/compiler/sbt.vim
@@ -20,8 +20,8 @@ set cpo-=C
 CompilerSet makeprg=sbt\ -Dsbt.log.noformat=true\ compile
 
 CompilerSet errorformat=
-      \%E\ %#[error]\ %f:%l:\ %m,%C\ %#[error]\ %p^,%-C%.%#,%Z,
-      \%W\ %#[warn]\ %f:%l:\ %m,%C\ %#[warn]\ %p^,%-C%.%#,%Z,
+      \%E\ %#[error]\ %f:%l:%c:\ %m,%C\ %#[error]\ %p^,%-C%.%#,%Z,
+      \%W\ %#[warn]\ %f:%l:%c:\ %m,%C\ %#[warn]\ %p^,%-C%.%#,%Z,
       \%-G%.%#
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
At some point, sbt added column numbers to its error messages. This handles them.