### PR TITLE
Clear highlights instead of link to Normal

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -118,7 +118,7 @@ hi link scalaTypePostExtension Keyword
 
 syn match scalaTypeAnnotation /\%([_a-zA-Z0-9$\s]:\_s*\)\ze[_=(\.A-Za-z0-9$]\+/ skipwhite nextgroup=scalaTypeDeclaration contains=scalaRoundBrackets
 syn match scalaTypeAnnotation /)\_s*:\_s*\ze[_=(\.A-Za-z0-9$]\+/ skipwhite nextgroup=scalaTypeDeclaration
-hi link scalaTypeAnnotation Normal
+hi clear scalaTypeAnnotation
 
 syn match scalaCaseFollowing /\<[_\.A-Za-z0-9$]\+\>/ contained contains=scalaCapitalWord
 syn match scalaCaseFollowing /`[^`]\+`/ contained contains=scalaCapitalWord
@@ -151,14 +151,14 @@ hi link scalaTripleIString String
 syn match scalaInterpolation /\$[a-zA-Z0-9_$]\+/ contained
 exe 'syn region scalaInterpolationB matchgroup=scalaInterpolationBoundary start=/\${/ end=/}/ contained contains=' . s:ContainedGroup()
 hi link scalaInterpolation Function
-hi link scalaInterpolationB Normal
+hi clear scalaInterpolationB
 
 syn region scalaFString matchgroup=scalaInterpolationBrackets start=/f"/ skip=/\\"/ end=/"/ contains=scalaFInterpolation,scalaFInterpolationB,scalaEscapedChar,scalaUnicodeChar
 syn match scalaFInterpolation /\$[a-zA-Z0-9_$]\+\(%[-A-Za-z0-9\.]\+\)\?/ contained
 exe 'syn region scalaFInterpolationB matchgroup=scalaInterpolationBoundary start=/${/ end=/}\(%[-A-Za-z0-9\.]\+\)\?/ contained contains=' . s:ContainedGroup()
 hi link scalaFString String
 hi link scalaFInterpolation Function
-hi link scalaFInterpolationB Normal
+hi clear scalaFInterpolationB
 
 syn region scalaTripleString start=/"""/ end=/"""\%([^"]\|$\)/ contains=scalaEscapedChar,scalaUnicodeChar
 syn region scalaTripleFString matchgroup=scalaInterpolationBrackets start=/f"""/ end=/"""\%([^"]\|$\)/ contains=scalaFInterpolation,scalaFInterpolationB,scalaEscapedChar,scalaUnicodeChar


### PR DESCRIPTION
Linking to the normal highlight group sets the background, this gives the wrong highlight in floating windows. See https://github.com/neoclide/coc.nvim/issues/1512