### PR TITLE
syntax: Fix word boundary of highlighting

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -210,15 +210,15 @@ hi link scalaAnnotation PreProc
 syn match scalaTrailingComment "//.*$" contains=scalaTodo,@Spell
 hi link scalaTrailingComment Comment
 
-syn match scalaAkkaFSM /goto([^)]*)\_s\+\<using\>/ contains=scalaAkkaFSMGotoUsing
-syn match scalaAkkaFSM /stay\_s\+using/
+syn match scalaAkkaFSM /\<goto([^)]*)\_s\+using\>/ contains=scalaAkkaFSMGotoUsing
+syn match scalaAkkaFSM /\<stay\_s\+using\>/
 syn match scalaAkkaFSM /^\s*stay\s*$/
-syn match scalaAkkaFSM /when\ze([^)]*)/
-syn match scalaAkkaFSM /startWith\ze([^)]*)/
-syn match scalaAkkaFSM /initialize\ze()/
-syn match scalaAkkaFSM /onTransition/
-syn match scalaAkkaFSM /onTermination/
-syn match scalaAkkaFSM /whenUnhandled/
+syn match scalaAkkaFSM /\<when\ze([^)]*)/
+syn match scalaAkkaFSM /\<startWith\ze([^)]*)/
+syn match scalaAkkaFSM /\<initialize\ze()/
+syn match scalaAkkaFSM /\<onTransition\>/
+syn match scalaAkkaFSM /\<onTermination\>/
+syn match scalaAkkaFSM /\<whenUnhandled\>/
 syn match scalaAkkaFSMGotoUsing /\<using\>/
 syn match scalaAkkaFSMGotoUsing /\<goto\>/
 hi link scalaAkkaFSM PreProc


### PR DESCRIPTION
Since vim-scala higlights `when` word without checking word boundary, it highlights a word like `elsewhen` partially.

This is a real code which I'm writing with Chisel3.

<img width="355" alt="スクリーンショット 2021-09-07 2 38 35" src="https://user-images.githubusercontent.com/823277/132250001-3a1c815e-f400-4bd4-9434-26bc34031119.png">

This PR fixes to check the word boundary. Now it does not highlight entire `elsewhen` method name correctly:

<img width="351" alt="スクリーンショット 2021-09-07 2 41 03" src="https://user-images.githubusercontent.com/823277/132250047-3603c2f8-e75d-4ab9-92ec-fbdd89987959.png">

I also found other words had the same issue so I fixed them as well.