### PR TITLE
Fix syntax for string literal in square brackets

### DIFF
--- a/syntax/scala.vim
+++ b/syntax/scala.vim
@@ -180,7 +180,7 @@ hi link scalaNumber Number
 
 syn region scalaRoundBrackets start="(" end=")" skipwhite contained contains=scalaTypeDeclaration,scalaSquareBrackets,scalaRoundBrackets
 
-syn region scalaSquareBrackets matchgroup=scalaSquareBracketsBrackets start="\[" end="\]" skipwhite nextgroup=scalaTypeExtension contains=scalaTypeDeclaration,scalaSquareBrackets,scalaTypeOperator,scalaTypeAnnotationParameter
+syn region scalaSquareBrackets matchgroup=scalaSquareBracketsBrackets start="\[" end="\]" skipwhite nextgroup=scalaTypeExtension contains=scalaTypeDeclaration,scalaSquareBrackets,scalaTypeOperator,scalaTypeAnnotationParameter,scalaString
 syn match scalaTypeOperator /[-+=:<>]\+/ contained
 syn match scalaTypeAnnotationParameter /@\<[`_A-Za-z0-9$]\+\>/ contained
 hi link scalaSquareBracketsBrackets Type

--- a/syntax/testfile.scala
+++ b/syntax/testfile.scala
@@ -171,6 +171,8 @@ class ScalaClass(i: Int = 12, b: Trait[A, Trait[B, C]]) extends B with SomeTrait
 
   def someFunc[A <: B, X =:= Y]
 
+  func["(singleton"]
+
   val soManyEscapes = "\\\"\u0031\n\b\r\f\t" // and a comment
   val soManyEscapes = """\\\"\u0031\n\b\r\f\t""" // and a comment
   val soManyEscapes = s"\\\"\u0031\n\b\r\f\t" // and a comment


### PR DESCRIPTION
Since https://docs.scala-lang.org/sips/42.type.html which is implemented in scala 2.13 and in scala 3 it possible to use string literals as singleton types. So code like
```
someFunc["abc"]
```
is valid. Currently this code is not hightlighted correctly and worse if there is an unclosed `(` in the string it breaks the formating in the rest of the file.